### PR TITLE
Fix the Average Price Section Default Text

### DIFF
--- a/backend/data.json
+++ b/backend/data.json
@@ -35,18 +35,6 @@
     {
       "name": "Magicure",
       "price": 200.0
-    },
-    {
-      "name": "aaa",
-      "price": 100.0
-    },
-    {
-      "name": "test",
-      "price": 123.0
-    },
-    {
-      "name": "Kayo",
-      "price": 23.0
     }
   ]
 }

--- a/backend/data.json
+++ b/backend/data.json
@@ -1,1 +1,52 @@
-{"medicines": [{"name": "Elixirium", "price": 5.99}, {"name": "Cureallium", "price": 7.49}, {"name": "Healix", "price": 4.99}, {"name": "Restorix", "price": 12.99}, {"name": "", "price": 15.49}, {"name": "Tonicast", "price": null}, {"name": "Allevium", "price": 19.99}, {"name": "Synthomaxi", "price": 14.99}, {"name": "Magicure", "price": 200.0}, {"name": "aaa", "price": 100.0}, {"name": "test", "price": 123.0}, {"name": "Kayo", "price": 23.0}]}
+{
+  "medicines": [
+    {
+      "name": "Elixirium",
+      "price": 5.99
+    },
+    {
+      "name": "Cureallium",
+      "price": 7.49
+    },
+    {
+      "name": "Healix",
+      "price": 4.99
+    },
+    {
+      "name": "Restorix",
+      "price": 12.99
+    },
+    {
+      "name": "",
+      "price": 15.49
+    },
+    {
+      "name": "Tonicast",
+      "price": null
+    },
+    {
+      "name": "Allevium",
+      "price": 19.99
+    },
+    {
+      "name": "Synthomaxi",
+      "price": 14.99
+    },
+    {
+      "name": "Magicure",
+      "price": 200.0
+    },
+    {
+      "name": "aaa",
+      "price": 100.0
+    },
+    {
+      "name": "test",
+      "price": 123.0
+    },
+    {
+      "name": "Kayo",
+      "price": 23.0
+    }
+  ]
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -67,7 +67,7 @@
                 <tbody>
                     <tr>
                         <!-- Add value using JavaScript -->
-                        <td id="average-value">Press the AVERAGE PRICE button to calculate the average price of all medicines.</td>
+                        <td id="average-value">Press the <strong>Calculate Average Price</strong> button to calculate the average price of all medicines.</td>
                     </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
## What I did:
- Change default text of the Average Price Section
- Make the button text strong in the default text to emphasize it for users
```html
<td id="average-value">Press the <strong>Calculate Average Price</strong> button to calculate the average price of all medicines.</td>
```

## Outcomes:
Align the default text into the button text correctly
![image](https://github.com/user-attachments/assets/695fbed4-e0f3-4282-9a1d-1785fb7eafaf)
